### PR TITLE
Add shell-script options

### DIFF
--- a/kyma-k3d-start.sh
+++ b/kyma-k3d-start.sh
@@ -1,3 +1,9 @@
+#!/usr/bin/env bash
+set -o errexit          # Exit on most errors (see the manual)
+set -o errtrace         # Make sure any error trap is inherited
+set -o nounset          # Disallow expansion of unset variables
+set -o pipefail         # Use last non-zero exit code in a pipeline
+
 k3d cluster start kyma --wait
 export KUBECONFIG="$(k3d kubeconfig merge kyma --switch-context)"
 # Wait for nodes to be ready before scheduling any workload

--- a/kyma-k3d.sh
+++ b/kyma-k3d.sh
@@ -1,3 +1,9 @@
+#!/usr/bin/env bash
+set -o errexit          # Exit on most errors (see the manual)
+set -o errtrace         # Make sure any error trap is inherited
+set -o nounset          # Disallow expansion of unset variables
+set -o pipefail         # Use last non-zero exit code in a pipeline
+
 SECONDS=0  
 REGISTRY_CONFIG=${1:-registries.yaml}
 
@@ -7,7 +13,7 @@ function waitForJobs() {
 }
 
 # Create docker network
-docker network create k3d-kyma
+docker network create k3d-kyma || echo "Network already exists"
 
 # Start docker Registry
 docker run -d \

--- a/kyma-k3d.sh
+++ b/kyma-k3d.sh
@@ -22,7 +22,7 @@ docker run -d \
   --name registry.localhost \
   --network k3d-kyma \
   -v $PWD/registry:/var/lib/registry \
-  registry:2
+  registry:2 || echo "Container already exists"
 
 # Create Kyma cluster
 k3d cluster create kyma \


### PR DESCRIPTION
Hi, 
thanks a lot for creating this setup-script for k3d, it has been quite helpful already :) 

One minor improvement suggestion: In its current form it could be potentially quite dangerous to use due to the missing error handling. If one of the commands fails, the other commands will still be executed. This can have unintended consequences if e.g. `k3d cluster ...` fails and the k8s-context is not updated. In that case, all the following `helm` & `kubectl` would be executed for the current which is probably not a good idea :D 
`set -o errexit` fixes that by aborting the script in case any of the commands fail. Further reading: http://www.yoone.eu/articles/2-good-practices-for-writing-shell-scripts.html

best wishes :) 