### PR TITLE
Adjust k3d memory usage in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains scripts to start Kyma on local kubernetes cluster (k3s)
 - [helm 3](https://helm.sh/docs/intro/quickstart/#install-helm)
 - [k3d](https://github.com/rancher/k3d) - you can install it with the command: `brew install k3d` or `curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash`
 - [jq](https://stedolan.github.io/jq/)
-- Docker configured with 7GB RAM
+- Docker configured with 8.25GB RAM
 
 # Quick start
 
@@ -123,7 +123,7 @@ K3d is a docker wrapper around k3s (which runs on linux only) - it is more or le
 ----|:-------:|:--------:|:----:|
 K8s installation + startup time | ~ 25 sec  | ~ 90 sec | ~ 100 sec 
 Cluster startup time (second run) | ~ 15 sec  | ~ 30 sec | ~ 30 sec 
-Allocated memory (e2e scenario) | 4.2 GB | 6.6 GB | 6.8 GB 
+Allocated memory (e2e scenario) | 5.2 GB | 6.6 GB | 6.8 GB 
 Kyma installation time | ~ 3 min | ~ 5-6 min | ~ 4-5 min 
 LoadBalancer support | yes | yes/no (requires another process for minikube tunnel command) | no 
 Expose LB ports on host machine (use localhost) | yes | yes(mac) / no(linux)  | yes/no (extraPortMappings to service exposed with NodePort) 


### PR DESCRIPTION
After trying the local k3d installation of kyma I found some slightly different memory requirements.

During startup `kyma-k3d.sh` needs at least 8.25 GB of memory due to [this part](https://github.com/kyma-incubator/local-kyma/blob/16c64c4ad809cb4b378a8a515b7fd76f7d6fc0b8/create-cluster-k3d.sh#L8) in the code.
```bash
./kyma-k3d.sh
Container memory is not sufficient. Please configure Docker to support containers with at least 8192 MB.
```
And the memoy usage of all docker containers shows ~ 5.2GB
```bash
docker stats --no-stream --format 'table {{.MemUsage}}' | sed 's/\.\([0-9]*\)GiB/\1MiB/g' | sed 's/[A-Za-z]*//g' | awk '{sum += $1} END {print sum "MB"}'
5227.97MB
```