### PR TITLE
Change alpine-kubectl image to k8s-tools

### DIFF
--- a/ingress-dns-cert/templates/job.yaml
+++ b/ingress-dns-cert/templates/job.yaml
@@ -13,7 +13,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ .Release.Name }}
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+        image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
         command: ["/bin/sh", ]
         args: ["-c","kubectl -n istio-system annotate service istio-ingressgateway dns.gardener.cloud/class=garden dns.gardener.cloud/dnsnames=*.$(GLOBAL_DOMAIN) --overwrite" ]
         env:
@@ -35,7 +35,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ .Release.Name }}-job1
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+        image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
         command: ["/bin/sh", ]
         args: ["-c","kubectl create secret tls kyma-gateway-certs -n kyma-system --cert=/etc/kyma-gateway-certs/tls.crt --key=/etc/kyma-gateway-certs/tls.key --dry-run -oyaml |
   kubectl apply -f -"]
@@ -43,7 +43,7 @@ spec:
         - name: cert
           mountPath: /etc/kyma-gateway-certs/
       - name: {{ .Release.Name }}-job2
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+        image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
         command: ["/bin/sh", ]
         args: ["-c","kubectl create secret generic ingress-tls-cert -n kyma-system --from-file=tls.crt=/etc/kyma-gateway-certs/tls.crt --dry-run -oyaml |
   kubectl apply -f -"]
@@ -51,7 +51,7 @@ spec:
         - name: cert
           mountPath: /etc/kyma-gateway-certs/
       - name: {{ .Release.Name }}-job3
-        image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200309-9a88ce97
+        image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
         command: ["/bin/sh", ]
         args: ["-c","kubectl create secret tls apiserver-proxy-tls-cert -n kyma-system --cert=/etc/kyma-gateway-certs/tls.crt --key=/etc/kyma-gateway-certs/tls.key --dry-run -oyaml |
   kubectl apply -f -"]


### PR DESCRIPTION
**Description**
Image `eu.gcr.io/kyma-project/test-infra/alpine-kubectl` is deprecated and removed from the test-infra repo. This PR changes image `eu.gcr.io/kyma-project/test-infra/alpine-kubectl` to `eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/3647